### PR TITLE
fix number animations being inferred as const

### DIFF
--- a/packages/ripple/src/index.d.ts
+++ b/packages/ripple/src/index.d.ts
@@ -139,17 +139,17 @@ export interface Motion<T extends Animatable = any> {
 	destroy(): void;
 }
 
-export function createSpring<T extends Animatable>(initialValue: T, options?: SpringOptions<T>): Spring<T>;
-
 export function createSpring(initialValue: number, options?: SpringOptions<number>): Spring<number>;
 
-export function createTween<T extends Animatable>(initialValue: T, options?: TweenOptions<T>): Tween<T>;
+export function createSpring<T extends Animatable>(initialValue: T, options?: SpringOptions<T>): Spring<T>;
 
 export function createTween(initialValue: number, options?: TweenOptions<number>): Tween<number>;
 
-export function createMotion<T extends Animatable>(initialValue: T, options?: MotionOptions<T>): Motion<T>;
+export function createTween<T extends Animatable>(initialValue: T, options?: TweenOptions<T>): Tween<T>;
 
 export function createMotion(initialValue: number, options?: MotionOptions<number>): Motion<number>;
+
+export function createMotion<T extends Animatable>(initialValue: T, options?: MotionOptions<T>): Motion<T>;
 
 export const config: {
 	default: SpringOptions;


### PR DESCRIPTION
Changes the order of the number overload for springs, tweens and motions so that a number wont be inferred as a const anymore.

<img width="1426" height="194" alt="image" src="https://github.com/user-attachments/assets/7cc0e303-7a47-4fb2-b962-9b2c1e9d1f3d" />
