### PR TITLE
Add figma spring options to index.d.ts

### DIFF
--- a/packages/ripple/src/index.d.ts
+++ b/packages/ripple/src/index.d.ts
@@ -158,6 +158,10 @@ export const config: {
 	stiff: SpringOptions;
 	slow: SpringOptions;
 	molasses: SpringOptions;
+	figmaGentle: SpringOptions;
+	figmaQuick: SpringOptions;
+	figmaBouncy: SpringOptions;
+	figmaSlow: SpringOptions;
 };
 
 export const easing: {


### PR DESCRIPTION
Adds figmaGentle, figmaQuick, figmaBouncy, figmaSlow to index.d.ts as it is missing